### PR TITLE
Add member sponsored legislation api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "congress-gov-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -10,23 +10,41 @@ info:
     This is NOT the official congress.gov YAML and contains modifications.
 
     Currently only supports 2/100 API operations.
+    
     Bill API: 0/16
+    
     Amendments API: 0/8
+    
     Summaries API: 0/3
+    
     Congress API: 0/3
-    Member API: 2/8
+    
+    Member API: 3/8
+    
     Committee API: 0/10
+    
     Committee Report API: 0/5
+    
     Committee Print API: 0/5
+    
     Committee Meeting API: 0/4
+    
     Hearing API: 0/4
+    
     Congressional Record API: 0/1
+    
     Daily Congressional Record API: 0/4
+    
     Bound Congressional Record API: 0/4
+    
     House Communication API: 0/4
+    
     House Requirement API: 0/3
+    
     Senate Communication API: 0/4
+    
     Nomination API: 0/7
+    
     Treaty API: 0/7
   contact:
     email: "liudotjson@gmail.com"
@@ -80,7 +98,29 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/CongressMemberDetailsErrorResponse"
+          $ref: "#/components/responses/MemberNotFoundErrorResponse"
+        "429":
+          $ref: "#/components/responses/RateLimitErrorResponse"
+  /member/{bioguideId}/sponsored-legislation:
+    get:
+      tags:
+        - "Congress"
+      summary: "Returns a list of legislation sponsored by a congressional member."
+      description: |
+        Get a list of legislation sponsored by a member.
+        Supports query parameters for pagination.
+      operationId: "getMemberSponsoredLegislation"
+      parameters:
+        - $ref: "#/components/parameters/BioguideId"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/LimitMax250"
+      responses:
+        "200":
+          $ref: "#/components/responses/MemberSponsoredLegislationResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/MemberNotFoundErrorResponse"
         "429":
           $ref: "#/components/responses/RateLimitErrorResponse"
 components:
@@ -135,6 +175,55 @@ components:
       schema:
         type: "boolean"
   schemas:
+    Pagination:
+      title: "Pagination"
+      description: "Pagination object."
+      type: "object"
+      required:
+        - "count"
+      properties:
+        count:
+          description: "Total number of records."
+          type: "integer"
+        next:
+          description: "URL of the next page of records."
+          type: "string"
+          format: "uri"
+        prev:
+          description: "URL of the next page of records."
+          type: "string"
+          format: "uri"
+    LegislationOverview:
+      description: "Legislation overview."
+      type: "object"
+      required:
+        - "congress"
+        - "introducedDate"
+        - "number"
+        - "policyArea"
+        - "title"
+        - "type"
+      properties:
+        congress:
+          $ref: "#/components/schemas/CongressNumber"
+        introducedDate:
+          $ref: "#/components/schemas/LegislationIntroducedDate"
+        latestAction:
+          $ref: "#/components/schemas/LegislationLatestAction"
+        number:
+          $ref: "#/components/schemas/LegislationNumber"
+        policyArea:
+          $ref: "#/components/schemas/PolicyArea"
+        title:
+          $ref: "#/components/schemas/LegislationTitle"
+        type:
+          $ref: "#/components/schemas/LegislationType"
+    CongressNumber:
+      description: "Congress number."
+      type: "integer"
+    LegislationNumber:
+      description: "Legislation number."
+      type: "string"
     BioguideId:
       description: "The member's Biographical Directory ID."
       type: "string"
@@ -175,8 +264,7 @@ components:
         chamber:
           $ref: "#/components/schemas/Chamber"
         congress:
-          description: "Congress number."
-          type: "integer"
+          $ref: "#/components/schemas/CongressNumber"
         district:
           description: "District number."
           type: "integer"
@@ -210,8 +298,7 @@ components:
         title: "LeadershipRole"
         properties:
           congress:
-            description: "Congress number."
-            type: "integer"
+            $ref: "#/components/schemas/CongressNumber"
           current:
             description: "Is the member currently serving."
             type: "boolean"
@@ -258,6 +345,41 @@ components:
       type: "string"
       pattern: "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
       format: "date-time"
+    LegislationIntroducedDate:
+      description: "Date the legislation was introduced. Format: YYYY-MM-DD."
+      type: "string"
+      pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+      format: "date"
+    LegislationLatestAction:
+      description: "Latest action on the legislation."
+      type: "object"
+      required:
+        - "actionDate"
+        - "text"
+      properties:
+        actionDate:
+          description: "Date of the action."
+          type: "string"
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+          format: "date"
+        text:
+          description: "Action text."
+          type: "string"
+    PolicyArea:
+      description: "Policy area."
+      type: "object"
+      required:
+        - "name"
+      properties:
+        name:
+          description: "Policy area name."
+          type: "string"
+    LegislationTitle:
+      description: "Legislation title."
+      type: "string"
+    LegislationType:
+      description: "Legislation type."
+      type: "string"
     BirthYear:
       description: "Year of birth."
       type: "integer"
@@ -373,23 +495,7 @@ components:
                     updateDate:
                       $ref: "#/components/schemas/UpdateDate"
               pagination:
-                title: "Pagination"
-                description: "Pagination object."
-                type: "object"
-                required:
-                  - "count"
-                properties:
-                  count:
-                    description: "Total number of records."
-                    type: "integer"
-                  next:
-                    description: "URL of the next page of records."
-                    type: "string"
-                    format: "uri"
-                  prev:
-                    description: "URL of the next page of records."
-                    type: "string"
-                    format: "uri"
+                $ref: "#/components/schemas/Pagination"
     CongressMemberListErrorResponse:
       description: "Bad request."
       content:
@@ -492,12 +598,30 @@ components:
                     $ref: "#/components/schemas/DetailedTerms"
                   updateDate:
                     $ref: "#/components/schemas/UpdateDate"
-    CongressMemberDetailsErrorResponse:
+    MemberSponsoredLegislationResponse:
+      description: "Member sponsored legislation."
+      content:
+        application/json:
+          schema:
+            title: "MemberSponsoredLegislationResponse"
+            type: "object"
+            required:
+              - "sponsoredLegislation"
+              - "pagination"
+            properties:
+              sponsoredLegislation:
+                description: "List of sponsored legislation."
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/LegislationOverview"
+              pagination:
+                $ref: "#/components/schemas/Pagination"
+    MemberNotFoundErrorResponse:
       description: "Member not found."
       content:
         application/json:
           schema:
-            title: "CongressMemberDetailsErrorResponse"
+            title: "MemberNotFoundErrorResponse"
             type: "object"
             required:
               - "error"
@@ -505,7 +629,6 @@ components:
               error:
                 description: "Error message."
                 type: "string"
-
     RateLimitErrorResponse:
       description: "Rate limit exceeded."
       content:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -51,7 +51,7 @@ info:
   license:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-  version: "0.1.2"
+  version: "0.1.3"
 externalDocs:
   description: "Official documentation"
   url: "https://api.congress.gov/"


### PR DESCRIPTION
This pull request includes updates to the `congress-gov-sdk` package, particularly enhancing the `swagger.yaml` file to include new endpoints and schemas, and updating the package version.

### Updates to `swagger.yaml`:

* Added a new endpoint to retrieve legislation sponsored by a congressional member (`/member/{bioguideId}/sponsored-legislation`).
* Introduced new schemas for `Pagination`, `LegislationOverview`, `LegislationIntroducedDate`, `LegislationLatestAction`, `PolicyArea`, `LegislationTitle`, and `LegislationType`. [[1]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R178-R226) [[2]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R348-R382)
* Updated existing schemas to reference the newly defined `CongressNumber` schema. [[1]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L178-R267) [[2]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L213-R301)
* Replaced inline `Pagination` schema definitions with a reference to the new `Pagination` schema.
* Added new response objects for `MemberSponsoredLegislationResponse` and `MemberNotFoundErrorResponse`.

### Version Update:

* Updated the package version from `0.1.2` to `0.1.3` in `package.json` and `swagger.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R3-L9) [[2]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R13-R54)