### PR TITLE
Rename terms.members to terms.item in accordance with API -- getMembers API

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -309,7 +309,7 @@ components:
       description: "Terms served."
       type: "object"
       properties:
-        members:
+        item:
           type: "array"
           items:
             $ref: "#/components/schemas/TermItem"


### PR DESCRIPTION
This pull request includes a change to the `swagger.yaml` file to improve the naming consistency of properties in the API schema.

Improvements to naming consistency:

* [`swagger.yaml`](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L312-R312): Renamed the `members` property to `item` in the `components` section to ensure consistent naming conventions.