### PR TITLE
Add DistrictNumber to members API

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -224,6 +224,9 @@ components:
     LegislationNumber:
       description: "Legislation number."
       type: "string"
+    DistrictNumber:
+      description: "District number."
+      type: integer
     BioguideId:
       description: "The member's Biographical Directory ID."
       type: "string"
@@ -266,8 +269,7 @@ components:
         congress:
           $ref: "#/components/schemas/CongressNumber"
         district:
-          description: "District number."
-          type: "integer"
+          $ref: "#/components/schemas/DistrictNumber"
         endYear:
           $ref: "#/components/schemas/TermEndYear"
         memberType:
@@ -474,6 +476,7 @@ components:
                   type: "object"
                   required:
                     - "bioguideId"
+                    - "district"
                     - "name"
                     - "partyName"
                     - "state"
@@ -484,6 +487,8 @@ components:
                       $ref: "#/components/schemas/BioguideId"
                     depiction:
                       $ref: "#/components/schemas/BioguideDepiction"
+                    district:
+                      $ref: "#/components/schemas/DistrictNumber"
                     name:
                       $ref: "#/components/schemas/Name"
                     partyName:
@@ -557,8 +562,7 @@ components:
                     description: "Direct order name."
                     type: "string"
                   district:
-                    description: "District number."
-                    type: integer
+                    $ref: "#/components/schemas/DistrictNumber"
                   firstName:
                     description: "First name."
                     type: "string"


### PR DESCRIPTION
This pull request includes changes to the `swagger.yaml` file to improve the consistency and reuse of schema definitions. The most important changes involve the introduction of a new schema for `DistrictNumber` and the replacement of inline definitions with references to this new schema.

Improvements to schema definitions:

* Added a new schema definition for `DistrictNumber` under `components` to standardize the district number representation.
* Updated the `district` field in multiple places to reference the new `DistrictNumber` schema instead of using inline definitions. [[1]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L269-R272) [[2]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L560-R565)

Enhancements to required fields:

* Added `district` as a required field in the relevant object definitions to ensure completeness of the data.

Schema updates for object properties:

* Updated object properties to use the new `DistrictNumber` schema for the `district` field, ensuring consistency across the file.