### PR TITLE
Add leadership field to member details, add member details tests

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -575,6 +575,8 @@ components:
                   lastName:
                     description: "Last name."
                     type: "string"
+                  leadership:
+                    $ref: "#/components/schemas/LeadershipRoles"
                   middleName:
                     description: "Middle name."
                     type: "string"

--- a/tests/member.test.ts
+++ b/tests/member.test.ts
@@ -1,9 +1,9 @@
 import {
     Configuration,
-    CongressApi,
+    CongressApi, CongressMemberDetailsResponse,
     CongressMemberListErrorResponse,
     ForbiddenErrorCodeEnum,
-    ForbiddenErrorResponse, RateLimitErrorCodeEnum, RateLimitErrorResponse
+    ForbiddenErrorResponse, MemberNotFoundErrorResponse, RateLimitErrorCodeEnum, RateLimitErrorResponse
 } from "../dist";
 import {
     CongressApiGetMembersRequest,
@@ -14,15 +14,236 @@ import MockAdapter from "axios-mock-adapter";
 import globalAxios, {AxiosError} from "axios";
 
 const mockedAxios: MockAdapter = new MockAdapter(globalAxios);
+const config = new Configuration({
+    apiKey: "test-api-key"
+});
+const api = new CongressApi(config);
+
+const invalidKeyTest = () => it("should handle 403 invalid key errors when fetching members", async () => {
+    mockedAxios.onGet().reply(403, {
+        "error": {
+            "code": "API_KEY_INVALID",
+            "message": "API key is invalid"
+        }
+    });
+
+    try {
+        await api.getMembers();
+    } catch (e) {
+        const error = e as AxiosError;
+        expect(error.message).toBe("Request failed with status code 403");
+        expect(error.response).toBeDefined();
+        expect(error.response!.status).toBe(403);
+        expect(error.response!.data).toBeDefined();
+        const errorResponse = error.response!.data as ForbiddenErrorResponse;
+        expect(errorResponse.error).toBeDefined();
+        expect(errorResponse.error.code).toBe(ForbiddenErrorCodeEnum.Invalid);
+        expect(errorResponse.error.message).toBe("API key is invalid");
+    }
+    expect.assertions(7);
+});
+
+const missingKeyTest = () => it("should handle 403 missing key errors when fetching members", async () => {
+    mockedAxios.onGet().reply(403, {
+        "error": {
+            "code": "API_KEY_MISSING",
+            "message": "API key is missing"
+        }
+    });
+    try {
+        await api.getMembers();
+    } catch (e) {
+        const error = e as AxiosError;
+        const errorResponse = error.response!.data as ForbiddenErrorResponse;
+        expect(errorResponse.error).toBeDefined();
+        expect(errorResponse.error.code).toBe(ForbiddenErrorCodeEnum.Missing);
+        expect(errorResponse.error.message).toBe("API key is missing");
+    }
+    expect.assertions(3);
+});
+
+const rateLimitTest = () => it("should handle 429 rate limit errors when fetching members", async () => {
+    mockedAxios.onGet().reply(429, {
+        "error": {
+            "code": "OVER_RATE_LIMIT",
+            "message": "Rate limit exceeded"
+        }
+    });
+
+    try {
+        await api.getMembers();
+    } catch (e) {
+        const error = e as AxiosError;
+        const errorResponse = error.response!.data as RateLimitErrorResponse;
+        expect(errorResponse.error).toBeDefined();
+        expect(errorResponse.error.code).toBe(RateLimitErrorCodeEnum.OverRateLimit);
+        expect(errorResponse.error.message).toBe("Rate limit exceeded");
+    }
+    expect.assertions(3);
+
+});
+
+describe("CongressApi - getMemberDetails", () => {
+    beforeEach(() => {
+        mockedAxios.reset();
+        jest.clearAllMocks()
+    });
+
+    it("should fetch member details successfully", async () => {
+        const mockResponse = {
+            member: {
+                addressInformation: {
+                    city: "Washington",
+                    district: "DC",
+                    officeAddress: "1234 Capitol Hill",
+                    phoneNumber: "(202) 225-5665",
+                    zipCode: 20515
+                },
+                bioguideId: "A000000",
+                birthYear: 1970,
+                cosponsoredLegislation: {
+                    count: 100
+                },
+                currentMember: true,
+                depiction: {
+                    "attribution": "Image courtesy of the Member",
+                    "imageUrl": "https://www.congress.gov/img/member/6734b6724c72e343a6aff9e6_200.jpg"
+                },
+                directOrderName: "John M. Doe",
+                district: 1,
+                firstName: "John",
+                honorificName: "Mr.",
+                invertedOrderName: "Doe, John M.",
+                lastName: "Doe",
+                leadership: [
+                    {
+                        congress: 115,
+                        current: false,
+                        type: "Speaker of the House"
+                    }
+                ],
+                middleName: "M.",
+                nickName: "Johnny",
+                officialWebsiteUrl: "https://www.doe.gov",
+                partyHistory: [
+                    {
+                        partyAbbreviation: "R",
+                        partyName: "Republican",
+                        startYear: 2000,
+                        endYear: 2024
+                    }
+                ],
+                sponsoredLegislation: {
+                    count: 100
+                },
+                state: "Louisiana",
+                terms: [
+                    {
+                        chamber: "House of Representatives",
+                        congress: 115,
+                        district: 4,
+                        endYear: 2019,
+                        memberType: "Representative",
+                        startYear: 2017,
+                        stateCode: "LA",
+                        stateName: "Louisiana"
+                    },
+                ],
+                updateDate: "2024-01-01T00:00:00Z"
+            }
+        };
+
+        mockedAxios.onGet(/\/v3\/member\/A000000(\?.*)?$/).reply(200, mockResponse);
+
+        const response = await api.getMemberDetails({bioguideId: "A000000"});
+        const data: CongressMemberDetailsResponse = response.data;
+
+        expect(data).toBeDefined();
+        expect(data.member).toBeDefined();
+        expect(data.member.addressInformation).toBeDefined();
+        expect(data.member.addressInformation!.city).toBe("Washington");
+        expect(data.member.addressInformation!.district).toBe("DC");
+        expect(data.member.addressInformation!.officeAddress).toBe("1234 Capitol Hill");
+        expect(data.member.addressInformation!.phoneNumber).toBe("(202) 225-5665");
+        expect(data.member.addressInformation!.zipCode).toBe(20515);
+        expect(data.member.bioguideId).toBe("A000000");
+        expect(data.member.birthYear).toBe(1970);
+        expect(data.member.cosponsoredLegislation).toBeDefined();
+        expect(data.member.cosponsoredLegislation!.count).toBe(100);
+        expect(data.member.currentMember).toBe(true);
+        expect(data.member.depiction).toBeDefined();
+        expect(data.member.depiction!.attribution).toBe("Image courtesy of the Member");
+        expect(data.member.depiction!.imageUrl).toBe("https://www.congress.gov/img/member/6734b6724c72e343a6aff9e6_200.jpg");
+        expect(data.member.directOrderName).toBe("John M. Doe");
+        expect(data.member.district).toBe(1);
+        expect(data.member.firstName).toBe("John");
+        expect(data.member.honorificName).toBe("Mr.");
+        expect(data.member.invertedOrderName).toBe("Doe, John M.");
+        expect(data.member.lastName).toBe("Doe");
+        expect(data.member.leadership).toBeDefined();
+        expect(data.member.leadership!.length).toBe(1);
+        expect(data.member.leadership![0].congress).toBe(115);
+        expect(data.member.leadership![0].current).toBe(false);
+        expect(data.member.leadership![0].type).toBe("Speaker of the House");
+        expect(data.member.middleName).toBe("M.");
+        expect(data.member.nickName).toBe("Johnny");
+        expect(data.member.officialWebsiteUrl).toBe("https://www.doe.gov");
+        expect(data.member.partyHistory).toBeDefined();
+        expect(data.member.partyHistory!.length).toBe(1);
+        expect(data.member.partyHistory![0].partyAbbreviation).toBe("R");
+        expect(data.member.partyHistory![0].partyName).toBe("Republican");
+        expect(data.member.partyHistory![0].startYear).toBe(2000);
+        expect(data.member.partyHistory![0].endYear).toBe(2024);
+        expect(data.member.sponsoredLegislation).toBeDefined();
+        expect(data.member.sponsoredLegislation!.count).toBe(100);
+        expect(data.member.state).toBe("Louisiana");
+        expect(data.member.terms).toBeDefined();
+        expect(data.member.terms!.length).toBe(1);
+        expect(data.member.terms![0].chamber).toBe(Chamber.HouseOfRepresentatives);
+        expect(data.member.terms![0].congress).toBe(115);
+        expect(data.member.terms![0].district).toBe(4);
+        expect(data.member.terms![0].endYear).toBe(2019);
+        expect(data.member.terms![0].memberType).toBe("Representative");
+        expect(data.member.terms![0].startYear).toBe(2017);
+        expect(data.member.terms![0].stateCode).toBe("LA");
+        expect(data.member.terms![0].stateName).toBe("Louisiana");
+        expect(data.member.updateDate).toBe("2024-01-01T00:00:00Z");
+        expect(mockedAxios.history.length).toBe(1);
+        const request = mockedAxios.history[0];
+        expect(request.data).toBeUndefined();
+        expect(request.url).toContain("?api_key=test-api-key");
+    });
+
+    describe("Error Handling", () => {
+        invalidKeyTest();
+        missingKeyTest();
+
+        it("should handle 404 errors when fetching member details", async () => {
+            mockedAxios.onGet().reply(404, {
+                "error": "Not found"
+            });
+
+            try {
+                await api.getMemberDetails({bioguideId: "A000000"});
+            } catch (e) {
+                const error = e as AxiosError;
+                expect(error.message).toBe("Request failed with status code 404");
+                expect(error.response).toBeDefined();
+                expect(error.response!.status).toBe(404);
+                expect(error.response!.data).toBeDefined();
+                const errorResponse = error.response!.data as MemberNotFoundErrorResponse;
+                expect(errorResponse.error).toBe("Not found");
+            }
+            expect.assertions(5);
+        });
+
+        rateLimitTest();
+    });
+});
 
 describe("CongressApi - getMembers", () => {
-    let api: CongressApi;
 
     beforeEach(() => {
-        const config = new Configuration({
-            apiKey: "test-api-key"
-        });
-        api = new CongressApi(config);
         mockedAxios.reset();
         jest.clearAllMocks();
     });
@@ -146,69 +367,8 @@ describe("CongressApi - getMembers", () => {
             expect.assertions(5);
         });
 
-        it("should handle 403 invalid key errors when fetching members", async () => {
-            mockedAxios.onGet().reply(403, {
-                "error": {
-                    "code": "API_KEY_INVALID",
-                    "message": "API key is invalid"
-                }
-            });
-
-            try {
-                await api.getMembers();
-            } catch (e) {
-                const error = e as AxiosError;
-                expect(error.message).toBe("Request failed with status code 403");
-                expect(error.response).toBeDefined();
-                expect(error.response!.status).toBe(403);
-                expect(error.response!.data).toBeDefined();
-                const errorResponse = error.response!.data as ForbiddenErrorResponse;
-                expect(errorResponse.error).toBeDefined();
-                expect(errorResponse.error.code).toBe(ForbiddenErrorCodeEnum.Invalid);
-                expect(errorResponse.error.message).toBe("API key is invalid");
-            }
-            expect.assertions(7);
-        });
-
-        it("should handle 403 missing key errors when fetching members", async () => {
-            mockedAxios.onGet().reply(403, {
-                "error": {
-                    "code": "API_KEY_MISSING",
-                    "message": "API key is missing"
-                }
-            });
-            try {
-                await api.getMembers();
-            } catch (e) {
-                const error = e as AxiosError;
-                const errorResponse = error.response!.data as ForbiddenErrorResponse;
-                expect(errorResponse.error).toBeDefined();
-                expect(errorResponse.error.code).toBe(ForbiddenErrorCodeEnum.Missing);
-                expect(errorResponse.error.message).toBe("API key is missing");
-            }
-            expect.assertions(3);
-        });
-
-
-        it("should handle 429 rate limit errors when fetching members", async () => {
-            mockedAxios.onGet().reply(429, {
-                "error": {
-                    "code": "OVER_RATE_LIMIT",
-                    "message": "Rate limit exceeded"
-                }
-            });
-
-            try {
-                await api.getMembers();
-            } catch (e) {
-                const error = e as AxiosError;
-                const errorResponse = error.response!.data as RateLimitErrorResponse;
-                expect(errorResponse.error).toBeDefined();
-                expect(errorResponse.error.code).toBe(RateLimitErrorCodeEnum.OverRateLimit);
-                expect(errorResponse.error.message).toBe("Rate limit exceeded");
-            }
-            expect.assertions(3);
-
-        });
+        invalidKeyTest();
+        missingKeyTest();
+        rateLimitTest();
     });
 });


### PR DESCRIPTION
This pull request includes several changes to the `swagger.yaml` file and the `tests/member.test.ts` file, focusing on adding new schema references and improving error handling in tests.

Schema updates:
* Added `leadership` reference to `components` in `swagger.yaml` to include leadership roles in member details.

Test improvements:
* Updated imports in `tests/member.test.ts` to include `CongressMemberDetailsResponse` and `MemberNotFoundErrorResponse`.
* Added configuration setup with `apiKey` and instantiated `CongressApi` for use in tests.
* Refactored error handling tests into separate functions for invalid key, missing key, and rate limit errors, and added a new test for fetching member details. [[1]](diffhunk://#diff-5994c432b07f403f0ecec97e81b7602660e7e67edcd181a8fc860d663f7b96f7R17-R246) [[2]](diffhunk://#diff-5994c432b07f403f0ecec97e81b7602660e7e67edcd181a8fc860d663f7b96f7L149-R372)