### PR TITLE
Add optional actionTime in sponsored legislation, add tests

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -364,6 +364,11 @@ components:
           type: "string"
           pattern: "^\\d{4}-\\d{2}-\\d{2}$"
           format: "date"
+        actionTime:
+          description: "Time of the action."
+          type: "string"
+          pattern: "^\\d{2}:\\d{2}:\\d{2}$"
+          format: "time"
         text:
           description: "Action text."
           type: "string"


### PR DESCRIPTION
This pull request includes updates to the `swagger.yaml` file and significant enhancements to the `tests/member.test.ts` file, focusing on adding new test cases and improving error handling.

Enhancements to the test cases:

* Added a new test case to handle 404 errors when fetching member details. (`tests/member.test.ts`)
* Added new test cases to fetch member-sponsored legislation successfully, including scenarios with optional parameters. (`tests/member.test.ts`)
* Refactored the error handling section to include the new 404 error test case. (`tests/member.test.ts`)

Updates to the `swagger.yaml` file:

* Added a new `actionTime` field with a description, type, pattern, and format for time. (`swagger.yaml`)