### PR TITLE
Add member cosponsored legislation api and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const members: CongressMemberOverview[] = response.data.members;
 ```
 
 ## Features
-Currently only supports 3 of the 100 available APIs
+Currently only supports 4 of the 100 available APIs
 
 Bill API: 0/16
 
@@ -52,7 +52,7 @@ Summaries API: 0/3
 
 Congress API: 0/3
 
-Member API: 3/8
+Member API: 4/8
 
 Committee API: 0/10
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -9,7 +9,7 @@ info:
 
     This is NOT the official congress.gov YAML and contains modifications.
 
-    Currently only supports 2/100 API operations.
+    Currently only supports 4/100 API operations.
     
     Bill API: 0/16
     
@@ -19,7 +19,7 @@ info:
     
     Congress API: 0/3
     
-    Member API: 3/8
+    Member API: 4/8
     
     Committee API: 0/10
     
@@ -117,6 +117,28 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/MemberSponsoredLegislationResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/MemberNotFoundErrorResponse"
+        "429":
+          $ref: "#/components/responses/RateLimitErrorResponse"
+  /member/{bioguideId}/cosponsored-legislation:
+    get:
+      tags:
+        - "Congress"
+      summary: "Returns a list of legislation cosponsored by a congressional member."
+      description: |
+        Get a list of legislation cosponsored by a member.
+        Supports query parameters for pagination.
+      operationId: "getMemberCosponsoredLegislation"
+      parameters:
+        - $ref: "#/components/parameters/BioguideId"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/LimitMax250"
+      responses:
+        "200":
+          $ref: "#/components/responses/MemberCosponsoredLegislationResponse"
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
@@ -622,6 +644,24 @@ components:
             properties:
               sponsoredLegislation:
                 description: "List of sponsored legislation."
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/LegislationOverview"
+              pagination:
+                $ref: "#/components/schemas/Pagination"
+    MemberCosponsoredLegislationResponse:
+      description: "Member cosponsored legislation."
+      content:
+        application/json:
+          schema:
+            title: "MemberCosponsoredLegislationResponse"
+            type: "object"
+            required:
+              - "cosponsoredLegislation"
+              - "pagination"
+            properties:
+              cosponsoredLegislation:
+                description: "List of cosponsored legislation."
                 type: "array"
                 items:
                   $ref: "#/components/schemas/LegislationOverview"

--- a/tests/member.test.ts
+++ b/tests/member.test.ts
@@ -1,9 +1,15 @@
 import {
     Configuration,
-    CongressApi, CongressApiGetMemberSponsoredLegislationRequest, CongressMemberDetailsResponse,
+    CongressApi,
+    CongressApiGetMemberCosponsoredLegislationRequest,
+    CongressApiGetMemberSponsoredLegislationRequest,
+    CongressMemberDetailsResponse,
     CongressMemberListErrorResponse,
     ForbiddenErrorCodeEnum,
-    ForbiddenErrorResponse, MemberNotFoundErrorResponse, RateLimitErrorCodeEnum, RateLimitErrorResponse
+    ForbiddenErrorResponse,
+    MemberNotFoundErrorResponse,
+    RateLimitErrorCodeEnum,
+    RateLimitErrorResponse
 } from "../dist";
 import {
     CongressApiGetMembersRequest,
@@ -191,6 +197,97 @@ describe("CongressApi - getMemberSponsoredLegislation", () => {
        memberNotFoundTest();
        rateLimitTest();
    });
+});
+
+describe("CongressApi - getMemberCosponsoredLegislation", () => {
+    beforeEach(() => {
+        mockedAxios.reset();
+        jest.clearAllMocks()
+    });
+
+    it("should fetch member cosponsored legislation successfully", async () => {
+        const mockResponse = {
+            cosponsoredLegislation: [
+                {
+                    congress: 115,
+                    introducedDate: "2017-01-01",
+                    latestAction: {
+                        actionDate: "2017-01-01",
+                        actionTime: "12:00:00",
+                        text: "Motion to reconsider laid on the table Agreed to without objection."
+                    },
+                    number: "1125",
+                    policyArea: {
+                        name: "Congress"
+                    },
+                    title: "Legislation title",
+                    type: "hres"
+                }
+            ],
+            pagination: {
+                count: 2,
+                next: "https://api.congress.gov/v3/member/A000000/cosponsored-legislation?offset=1",
+            }
+        };
+
+        mockedAxios.onGet(/\/v3\/member\/A000000\/cosponsored-legislation(\?.*)?$/).reply(200, mockResponse);
+
+        const response = await api.getMemberCosponsoredLegislation({bioguideId: "A000000"});
+        const data = response.data;
+
+        expect(data).toBeDefined();
+        expect(data.cosponsoredLegislation).toBeDefined();
+        expect(data.cosponsoredLegislation.length).toBe(1);
+        expect(data.cosponsoredLegislation[0].congress).toBe(115);
+        expect(data.cosponsoredLegislation[0].introducedDate).toBe("2017-01-01");
+        expect(data.cosponsoredLegislation[0].latestAction).toBeDefined();
+        expect(data.cosponsoredLegislation[0].latestAction!.actionDate).toBe("2017-01-01");
+        expect(data.cosponsoredLegislation[0].latestAction!.actionTime).toBe("12:00:00");
+        expect(data.cosponsoredLegislation[0].latestAction!.text).toBe("Motion to reconsider laid on the table Agreed to without objection.");
+        expect(data.cosponsoredLegislation[0].number).toBe("1125");
+        expect(data.cosponsoredLegislation[0].policyArea).toBeDefined();
+        expect(data.cosponsoredLegislation[0].policyArea!.name).toBe("Congress");
+        expect(data.cosponsoredLegislation[0].title).toBe("Legislation title");
+        expect(data.cosponsoredLegislation[0].type).toBe("hres");
+        expect(data.pagination).toBeDefined();
+        expect(data.pagination.count).toBe(2);
+        expect(data.pagination.next).toBe("https://api.congress.gov/v3/member/A000000/cosponsored-legislation?offset=1");
+        expect(data.pagination.prev).toBeUndefined();
+        expect(mockedAxios.history.length).toBe(1);
+    });
+
+    it("should fetch member cosponsored legislation with all optional parameters", async () => {
+        const mockResponse = {
+            cosponsoredLegislation: [],
+            pagination: {
+                count: 0
+            }
+        }
+
+        mockedAxios.onGet().reply(200, mockResponse);
+
+        const params: CongressApiGetMemberCosponsoredLegislationRequest = {
+            bioguideId: "A00000",
+            offset: 10,
+            limit: 50
+        }
+
+        await api.getMemberCosponsoredLegislation(params);
+
+        expect(mockedAxios.history.length).toBe(1);
+        const request = mockedAxios.history[0];
+        expect(request.data).toBeUndefined();
+        expect(request.url).toContain("api_key=test-api-key");
+        expect(request.url).toContain("offset=10");
+        expect(request.url).toContain("limit=50");
+    });
+
+    describe("Error Handling", () => {
+        invalidKeyTest();
+        missingKeyTest();
+        memberNotFoundTest();
+        rateLimitTest();
+    });
 });
 
 describe("CongressApi - getMemberDetails", () => {


### PR DESCRIPTION
This pull request includes updates to the `README.md`, `swagger.yaml`, and `tests/member.test.ts` files to support a new API endpoint for fetching cosponsored legislation by a congressional member. The changes also include updates to the documentation and test cases.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R45): Updated the number of supported APIs from 3 to 4 and the number of supported operations in the Member API from 3/8 to 4/8. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R45) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R55)
* [`swagger.yaml`](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L12-R12): Updated the supported API operations count from 2/100 to 4/100 and the number of supported operations in the Member API from 3/8 to 4/8. [[1]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L12-R12) [[2]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L22-R22)

### New API Endpoint:
* [`swagger.yaml`](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R126-R147): Added a new endpoint `/member/{bioguideId}/cosponsored-legislation` to fetch cosponsored legislation by a congressional member, including query parameters for pagination and response definitions. [[1]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R126-R147) [[2]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R652-R669)

### Test Cases:
* [`tests/member.test.ts`](diffhunk://#diff-5994c432b07f403f0ecec97e81b7602660e7e67edcd181a8fc860d663f7b96f7L3-R12): Added test cases for the new `getMemberCosponsoredLegislation` endpoint, including tests for successful data fetching, optional parameters, and error handling. [[1]](diffhunk://#diff-5994c432b07f403f0ecec97e81b7602660e7e67edcd181a8fc860d663f7b96f7L3-R12) [[2]](diffhunk://#diff-5994c432b07f403f0ecec97e81b7602660e7e67edcd181a8fc860d663f7b96f7R202-R292)