### PR TITLE
Make various fields in DetailedTermItem required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "congress-gov-sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Axios Typescript SDK for the Congress.gov API",
   "keywords": [
     "congress",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -51,7 +51,7 @@ info:
   license:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-  version: "0.1.4"
+  version: "0.1.5"
 externalDocs:
   description: "Official documentation"
   url: "https://api.congress.gov/"
@@ -285,6 +285,14 @@ components:
     DetailedTermItem:
       description: "Detailed term in Congress."
       type: "object"
+      required:
+        - "chamber"
+        - "congress"
+        - "district"
+        - "memberType"
+        - "startyear"
+        - "stateCode"
+        - "stateName"
       properties:
         chamber:
           $ref: "#/components/schemas/Chamber"


### PR DESCRIPTION
This pull request includes updates to the versioning and schema requirements for the `congress-gov-sdk` project. The most important changes are as follows:

Schema requirements:
* [`swagger.yaml`](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R288-R295): Added required fields to the `DetailedTermItem` schema, including `chamber`, `congress`, `district`, `memberType`, `startyear`, `stateCode`, and `stateName`.